### PR TITLE
Fixes #7: Can't build the samples based on the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@ To check out the project and build it, do the following:
  
 ### Download the Solace C# API
 
-The C# API library can be [downloaded here](http://dev.solace.com/downloads/). The build instructions below assume you have unpacked the tar file into `src` subdirectory of your GitHub repository. 
+The C# API library can be [downloaded here]({{ site.links-downloads }}){:target="_top"}. The build instructions below assume you have unpacked the zip file to a known location. 
 
 ### Build the Samples
 
 Building these examples is simple. The following provides an example. For ideas on how to build with other IDEs you can consult the README of the C# API library.
 
 ```
-> csc TopicPublisher.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicPublisher.exe
-> csc TopicSubscriber.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicSubscriber.exe
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicPublisher.exe  TopicPublisher.cs
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicSubscriber.exe  TopicSubscriber.cs
 ```
+
+You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your source and executables are. 
+
+Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution. 
 
 ## Running the Samples
 

--- a/docs/_tutorials/confirmed-delivery.md
+++ b/docs/_tutorials/confirmed-delivery.md
@@ -182,7 +182,7 @@ Combining the example source code show above results in the following source cod
 
 ### Building
 
-Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+Modify the example source code to reflect your Solace messaging router message-vpn name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 

--- a/docs/_tutorials/confirmed-delivery.md
+++ b/docs/_tutorials/confirmed-delivery.md
@@ -182,19 +182,21 @@ Combining the example source code show above results in the following source cod
 
 ### Building
 
+Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+
 Build it from Microsoft Visual Studio or command line:
 
 ```
-csc ConfirmedPublish.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out: ConfirmedPublish.exe
+csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out: ConfirmedPublish.exe ConfirmedPublish.cs
 ```
 
-You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your executables are.
+You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your source and executables are. 
 
-Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution.
+Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution. 
 
 ### Sample Output
 
-Start the `ConfirmedPublish` to send messages to the queue and see confirmations.
+Start the `ConfirmedPublish` to send messages to the queue, passing your Solace messaging router host name (or IP address) as parameter and see confirmations.
 
 ```
 $ ./ConfirmedPublish HOST

--- a/docs/_tutorials/persistence-with-queues.md
+++ b/docs/_tutorials/persistence-with-queues.md
@@ -165,7 +165,7 @@ Combining the example source code show above results in the following source cod
 
 ### Building
 
-Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+Modify the example source code to reflect your Solace messaging router message-vpn name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 

--- a/docs/_tutorials/persistence-with-queues.md
+++ b/docs/_tutorials/persistence-with-queues.md
@@ -165,20 +165,22 @@ Combining the example source code show above results in the following source cod
 
 ### Building
 
+Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+
 Build it from Microsoft Visual Studio or command line:
 
 ```
-> csc QueueProducer.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out: QueueProducer.exe
-> csc QueueConsumer.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out: QueueConsumer.exe
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out: QueueProducer.exe QueueProducer.cs
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out: QueueConsumer.exe QueueConsumer.cs
 ```
 
-You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your executables are.
+You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your source and executables are. 
 
-Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution.
+Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution. 
 
 ### Sample Output
 
-First start the `QueueProducer` to send a message to the queue. Then you can use the `QueueConsumer` sample to receive the messages from the queue.
+First start the `QueueProducer` to send a message to the queue. Then you can use the `QueueConsumer` sample to receive the messages from the queue. Pass your Solace messaging router host name (or IP address) as parameter.
 
 ```
 $ ./QueueProducer HOST

--- a/docs/_tutorials/publish-subscribe.md
+++ b/docs/_tutorials/publish-subscribe.md
@@ -197,22 +197,22 @@ Combining the example source code shown above results in the following source co
 
 ## Building 
 
-Modify the example source code to reflect your Solace messaging router host name (or IP address). 
+Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 
 ```
-> csc TopicPublisher.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicPublisher.exe
-> csc TopicSubscriber.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicSubscriber.exe
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicPublisher.exe  TopicPublisher.cs
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicSubscriber.exe  TopicSubscriber.cs
 ```
 
-You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your executables are. 
+You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your source and executables are. 
 
 Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution. 
 
 ## Sample Output 
 
-First start the `TopicSubscriber.exe` so that it is up and waiting for published messages. Then you can use the `TopicPublisher.exe` sample to publish a message.
+First start the `TopicSubscriber.exe` so that it is up and waiting for published messages. Then you can use the `TopicPublisher.exe` sample to publish a message. Pass your Solace messaging router host name (or IP address) as parameter.
 
 ```
 $ ./TopicSubscriber HOST

--- a/docs/_tutorials/publish-subscribe.md
+++ b/docs/_tutorials/publish-subscribe.md
@@ -197,7 +197,7 @@ Combining the example source code shown above results in the following source co
 
 ## Building 
 
-Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+Modify the example source code to reflect your Solace messaging router message-vpn name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 

--- a/docs/_tutorials/request-reply.md
+++ b/docs/_tutorials/request-reply.md
@@ -169,22 +169,22 @@ cd {{ site.baseurl | remove: '/'}}
 
 ### Building
 
-Modify the example source code to reflect your Solace messaging router host name (or IP address), its Virtual Private Network (VPN) name and credentials for connection (client username and optional password).
+Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 
 ```
-> csc BasicReplier.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:BasicReplier.exe
-> csc BasicRequestor.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:BasicRequestor.exe
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:BasicReplier.exe BasicReplier.cs
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:BasicRequestor.exe BasicRequestor.cs
 ```
 
-You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your executables are.
+You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your source and executables are. 
 
-Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution.
+Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution. 
 
 ### Running the Sample
 
-First start the BasicReplier.exe so that it is up and listening for requests. Then you can use the BasicRequestor.exe sample to send requests and receive replies.
+First start the BasicReplier.exe so that it is up and listening for requests. Then you can use the BasicRequestor.exe sample to send requests and receive replies. Pass your Solace messaging router host name (or IP address) as parameter.
 
 ```
 $ ./BasicReplier HOST

--- a/docs/_tutorials/request-reply.md
+++ b/docs/_tutorials/request-reply.md
@@ -169,7 +169,7 @@ cd {{ site.baseurl | remove: '/'}}
 
 ### Building
 
-Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+Modify the example source code to reflect your Solace messaging router message-vpn name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 

--- a/docs/_tutorials/topic-to-queue-mapping.md
+++ b/docs/_tutorials/topic-to-queue-mapping.md
@@ -169,7 +169,7 @@ The full source code for this example is available in [GitHub]({{ site.repositor
 
 ### Building
 
-Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+Modify the example source code to reflect your Solace messaging router message-vpn name and credentials for connection (client username and optional password) as needed.
 
 Build it from Microsoft Visual Studio or command line:
 

--- a/docs/_tutorials/topic-to-queue-mapping.md
+++ b/docs/_tutorials/topic-to-queue-mapping.md
@@ -169,19 +169,21 @@ The full source code for this example is available in [GitHub]({{ site.repositor
 
 ### Building
 
+Modify the example source code to reflect your Solace messaging router Virtual Private Network (VPN) name and credentials for connection (client username and optional password) as needed.
+
 Build it from Microsoft Visual Studio or command line:
 
 ```
-> csc TopicToQueueMapping.cs /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicToQueueMapping.exe
+> csc /reference:SolaceSystems.Solclient.Messaging_64.dll /optimize /out:TopicToQueueMapping.exe TopicToQueueMapping.cs
 ```
 
-You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your executables are.
+You need `SolaceSystems.Solclient.Messaging_64.dll` at compile and runtime time and `libsolclient_64.dll` at runtime in the same directory where your source and executables are. 
 
 Both DLLs are part of the Solace C#/.NET API distribution and located in `solclient-dotnet\lib` directory of that distribution.
 
 ### Sample Output
 
-Start the TopicToQueueMapping to send and receive messages.
+Start the TopicToQueueMapping to send and receive messages, passing your Solace messaging router host name (or IP address) as parameter.
 
 ```
 $ ./TopicToQueueMapping HOST


### PR DESCRIPTION
- Clarified that the download format is .zip and it doesn't need to be extracted to the src folder but to any known location.
- Also that the build examples require the dll's to be in the same dir as the cs source and executable (was already there elsewhere)
- The build examples were failing because the source reference needs to be the last in the command.
- Also modified the description which called for the host name to be modified in the code instead of passing as parameter.