### PR TITLE
Removed unwanted merge tags that were being displayed on the UI

### DIFF
--- a/docs/_includes/solace-cloud-dependency.html
+++ b/docs/_includes/solace-cloud-dependency.html
@@ -1,8 +1,4 @@
 <!-- Required files for solace cloud style -->
-<<<<<<< HEAD
-=======
-
->>>>>>> samples-template/master
 {% include solace-cloud-analytics.html %}
 
 <link rel="stylesheet" href="{{ "/css/materialize.min.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
Removed unwanted merge tags that were being displayed on the top of the page on solace cloud

![screencapture-cloud-solace-samples-solace-samples-dotnet-1518729170223](https://user-images.githubusercontent.com/22405222/36281288-29775494-126b-11e8-824a-5d34db94dd72.png)
![screen shot 2018-02-15 at 4 13 08 pm](https://user-images.githubusercontent.com/22405222/36281297-2de8a0fa-126b-11e8-85a7-b110762de002.png)